### PR TITLE
Add GitHub Action to build and upload Gradle plugin

### DIFF
--- a/gradle-build.yml
+++ b/gradle-build.yml
@@ -1,0 +1,33 @@
+name: Gradle Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vLobbyConnect
+          path: build/libs/*.jar


### PR DESCRIPTION
Add a new GitHub Actions workflow file `gradle-build.yml` to build the Gradle plugin and upload it to artifacts.